### PR TITLE
Update to Java 25 LTS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+target/
+.git/
+.gitignore
+.idea/
+*.iml
+db/
+*.odb

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '22'
+          java-version: '25'
           distribution: 'temurin'
           maven-version: '3.9.6'
           cache: maven

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Build stage
+FROM maven:3.9-eclipse-temurin-25 AS build
+WORKDIR /build
+
+COPY pom.xml .
+RUN mvn -B -q dependency:go-offline
+
+COPY src ./src
+RUN mvn -B -q package \
+    && mvn -B -q dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target/lib
+
+# Runtime stage
+FROM eclipse-temurin:25-jre
+WORKDIR /app
+
+COPY --from=build /build/target/classes/ /app/classes/
+COPY --from=build /build/target/lib/ /app/lib/
+
+RUN useradd --create-home --shell /bin/bash appuser \
+    && mkdir -p /app/db \
+    && chown -R appuser:appuser /app
+
+USER appuser
+
+ENTRYPOINT ["java", "-cp", "/app/lib/*:/app/classes", "com.progys.interview.quiz.FigureIntersection"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This project was written as a solution to a Java developer job interview quiz. T
 - Additional commands: `list`, `clear`, `help`, `exit`
 - Meaningful error messages for unexpected input; execution continues after an error
 - Continuous integration via GitHub Actions
+- Docker image based on the same Java 25 runtime
 
 ## Prerequisites
 
@@ -49,6 +50,34 @@ You can also build a runnable JAR and execute it:
 ```bash
 mvn clean package
 java -jar target/FigureIntersection-1.0-SNAPSHOT.jar -f shapesInput.txt
+```
+
+## Running with Docker
+
+The provided `Dockerfile` builds and runs the application on the **same Java version (Java 25)**. No local JDK or Maven installation is required.
+
+Build the image:
+
+```bash
+docker build -t figure-intersection .
+```
+
+Run the application interactively (the app needs an interactive terminal):
+
+```bash
+docker run -it --rm figure-intersection
+```
+
+Load shapes from a file (mount the file into the container):
+
+```bash
+docker run -it --rm -v "$PWD/shapesInput.txt:/app/shapesInput.txt:ro" figure-intersection -f shapesInput.txt
+```
+
+The shapes database is stored inside the container at `/app/db`. To keep it between runs, mount a host directory:
+
+```bash
+docker run -it --rm -v "$PWD/db:/app/db" figure-intersection
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This project was written as a solution to a Java developer job interview quiz. T
 ## Prerequisites
 
 - Maven 3
-- Java 22
+- Java 25
 - Internet connection (to download dependencies)
 
 ## Building and running
@@ -103,7 +103,7 @@ Shapes can also be loaded from a file with `-f <filename>` (see `shapesInput.txt
 
 ## Technologies and libraries
 
-- **Java 22** — language features and Java streams
+- **Java 25** — language features and Java streams
 - **Maven** — build tool and dependency management
 - **Java Streams** — parallel processing for point queries
 - **Guice** — dependency injection

--- a/pom.xml
+++ b/pom.xml
@@ -103,10 +103,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.15.0</version>
                 <configuration>
-                    <source>22</source>
-                    <target>22</target>
-                    <testSource>22</testSource>
-                    <testTarget>22</testTarget>
+                    <release>25</release>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Summary

Bumps the project from **Java 22** to **Java 25 LTS** and adds Docker support on the same Java 25 runtime.

- `pom.xml`: replace `source`/`target`/`testSource`/`testTarget` (22) with `<release>25</release>` in `maven-compiler-plugin`
- `.github/workflows/maven.yml`: CI now runs on `java-version: '25'`
- `README.md`: prerequisites and tech stack updated to Java 25; new "Running with Docker" section
- `Dockerfile`: multi-stage build (`maven:3.9-eclipse-temurin-25` → `eclipse-temurin:25-jre`), runs as non-root user
- `.dockerignore`: keeps the build context minimal

## Verification

Verified on Temurin JDK 25.0.4:
- `mvn clean test`: all 9 tests pass
- `mvn clean package`: build succeeds
- App runs end-to-end with file input
- The container's exact runtime layout (`/app/classes` + `/app/lib/*` on the classpath) was simulated locally: ObjectDB enhancer runs, shapes persist and query correctly

> Note: Docker is not installed on this machine, so `docker build` itself was not executed here — CI runs `mvn package`, and the runtime layout was verified locally. Please run `docker build -t figure-intersection .` to confirm the image builds.