### PR TITLE
Fix workflow permissions for dependency graph step

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,6 +14,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,11 +27,11 @@ jobs:
         with:
           java-version: '25'
           distribution: 'temurin'
-          maven-version: '3.9.6'
           cache: maven
       - name: Build with Maven
         run: mvn -B package --file pom.xml
       - name: Test with Maven
         run: mvn clean compile test
       - name: Update dependency graph
+        if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}
         uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6


### PR DESCRIPTION
## Summary

The build workflow had no explicit `permissions` block, which GitHub flags as an error, and the `advanced-security/maven-dependency-submission-action` step failed on Dependabot-triggered PRs with "Resource not accessible by integration" (their `GITHUB_TOKEN` is read-only).

Changes in `.github/workflows/maven.yml`:

- Added `permissions: contents: write` at the workflow level (required by the dependency submission action)
- Guarded the "Update dependency graph" step so it only runs on `push` or same-repo PRs from non-Dependabot authors
- Removed the invalid `maven-version: '3.9.6'` input from `actions/setup-java@v4` (not a valid input; Maven is preinstalled on the runner)