### PR TITLE
Fix nondeterministic concurrency in PointCommand

### DIFF
--- a/src/main/java/com/progys/interview/quiz/commands/PointCommand.java
+++ b/src/main/java/com/progys/interview/quiz/commands/PointCommand.java
@@ -7,8 +7,7 @@ import com.progys.interview.quiz.persistence.StoredShape;
 import com.progys.interview.quiz.persistence.Store;
 
 import java.io.PrintStream;
-import java.util.Collection;
-import java.util.function.Consumer;
+import java.util.List;
 
 /**
  * Defines action for point input.
@@ -28,18 +27,23 @@ public class PointCommand extends AbstractCommand {
 
     @Override
     public void process() {
-        Collection<StoredShape> shapes = persistence.getAll();
-        printShapes(shapes);
+        List<StoredShape> containing = persistence.getAll().parallelStream()
+                .filter(stored -> stored.shape().inShape(point))
+                .toList();
+        printShapes(containing);
     }
 
-    private void printShapes(Collection<StoredShape> shapes) {
+    private void printShapes(List<StoredShape> containing) {
         output.println(String.format("Shape list containing point %s:", point));
 
-        AreaConsumer areaConsumer = shapes.parallelStream()
-                .filter(stored -> stored.shape().inShape(point))
-                .collect(AreaConsumer::new, AreaConsumer::accept, AreaConsumer::combine);
+        double totalArea = 0;
+        for (StoredShape stored : containing) {
+            totalArea += stored.shape().getArea();
+            output.println(String.format("%s; Shape area: %.2f", stored,
+                    stored.shape().getArea()));
+        }
 
-        printTotalSurfaceArea(areaConsumer.totalArea, areaConsumer.count);
+        printTotalSurfaceArea(totalArea, containing.size());
     }
 
     private void printTotalSurfaceArea(double totalArea, long shapesCount) {
@@ -54,22 +58,5 @@ public class PointCommand extends AbstractCommand {
 
     private void noShapesContainingPoint() {
         output.println("No shapes found. Total surface area: 0");
-    }
-
-    private class AreaConsumer implements Consumer<StoredShape> {
-        private double totalArea = 0;
-        private int count = 0;
-
-        public void accept(StoredShape stored) {
-            totalArea += stored.shape().getArea();
-            count++;
-            output.println(String.format("%s; Shape area: %.2f", stored,
-                    stored.shape().getArea()));
-        }
-
-        public void combine(AreaConsumer other) {
-            totalArea += other.totalArea;
-            count += other.count;
-        }
     }
 }

--- a/src/test/java/com/progys/interview/quiz/commands/PointCommandTest.java
+++ b/src/test/java/com/progys/interview/quiz/commands/PointCommandTest.java
@@ -1,0 +1,54 @@
+package com.progys.interview.quiz.commands;
+
+import com.progys.interview.quiz.model.Circle;
+import com.progys.interview.quiz.model.Point;
+import com.progys.interview.quiz.persistence.StoredShape;
+import com.progys.interview.quiz.persistence.Store;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+class PointCommandTest {
+
+    @Test
+    void printsContainingShapesInEncounterOrder() {
+        Store mockStore = Mockito.mock(Store.class);
+        StoredShape insideSmall = new StoredShape(1L, new Circle(new Point(0, 0), 1));
+        StoredShape outside = new StoredShape(2L, new Circle(new Point(100, 100), 1));
+        StoredShape insideBig = new StoredShape(3L, new Circle(new Point(0, 0), 2));
+        when(mockStore.getAll()).thenReturn(List.of(insideSmall, outside, insideBig));
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        PointCommand pointCommand =
+                new PointCommand(new Point(0, 0), mockStore, new PrintStream(outputStream));
+
+        pointCommand.process();
+
+        String output = outputStream.toString();
+        assertThat(output).containsSubsequence("=> Shape 1:", "=> Shape 3:");
+        assertThat(output).doesNotContain("=> Shape 2:");
+        assertThat(output).contains(
+                "Found 2 shapes containing point (0.0, 0.0). Surface area combined:  15.7080");
+    }
+
+    @Test
+    void printsNoShapesFoundWhenNothingContainsPoint() {
+        Store mockStore = Mockito.mock(Store.class);
+        StoredShape outside = new StoredShape(1L, new Circle(new Point(100, 100), 1));
+        when(mockStore.getAll()).thenReturn(List.of(outside));
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        PointCommand pointCommand =
+                new PointCommand(new Point(0, 0), mockStore, new PrintStream(outputStream));
+
+        pointCommand.process();
+
+        assertThat(outputStream.toString()).contains("No shapes found. Total surface area: 0");
+    }
+}


### PR DESCRIPTION
## Problem

\`PointCommand\` performed its work in a parallel stream via a mutable \`AreaConsumer\` that accumulated \`totalArea\` **and printed each matching shape from inside \`accept()\`**, which runs on worker threads. Consequences:

- Shape lines were printed in nondeterministic order across runs.
- The \`totalArea\` float sum order varied run to run.

## Fix

- The parallel stream now only computes matches: \`parallelStream().filter(shape.inShape(point)).toList()\` — no shared mutable state, and \`toList()\` preserves encounter order.
- Printing and the area summation happen afterwards in a single sequential loop, so output ordering and the float result are deterministic.

## Verification

- New \`PointCommandTest\` (2 cases): encounter-order + combined area output, and empty-result path. Full suite now 11/11 green.
- End-to-end: two runs of a parallel point query produce byte-identical output (same hash).